### PR TITLE
remove unnecessary "short" from docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,7 @@
             <p>
               <code>Artifact</code> objects contain:
               <dl class="dl-horizontal">
-                <dt>version</dt><dd>The short version string of the Go release the artifact is from.</dd>
+                <dt>version</dt><dd>The version string of the Go release the artifact is from.</dd>
                 <dt>link</dt><dd>The URL where the artifact can be downloaded.</dd>
                 <dt>kind</dt><dd>The kind can be either <code>"Source"</code> (it's the source code for the artifact), <code>"Installer"</code> (a binary installer tool for a given platform), or <code>"Archive"</code> (a compiled form of the Go release for that platform).</dd>
                 <dt>os</dt><dd>The operating system the artifact is meant to be used on (if a specific one exists).</dd>


### PR DESCRIPTION
(This is mostly to debug our GitHub PR requirement settings.)