### PR TITLE
improve the create-pull-request config

### DIFF
--- a/.github/workflows/rebuild_api.yml
+++ b/.github/workflows/rebuild_api.yml
@@ -25,6 +25,9 @@ jobs:
         uses: peter-evans/create-pull-request@v1.5.2
         env:
           PULL_REQUEST_TITLE: ${{ steps.pr_title_maker.outputs.pr_title }}
-          COMMIT_MESSAGE: ${{ steps.pr_title_maker.outputs.pr_title }}
+          PULL_REQUEST_BODY: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and our own [rebuild_api.yml](https://github.com/jmhodges/goreleaseapi/blob/master/.github/workflows/rebuild_api.yml).
+          COMMIT_MESSAGE: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and our own [rebuild_api.yml](https://github.com/jmhodges/goreleaseapi/blob/master/.github/workflows/rebuild_api.yml).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_LABELS: autorebuild,autorebase
+          BRANCH_SUFFIX: none
+          PULL_REQUEST_BRANCH: ensure-latest-go/patch-${{ steps.ensure_go.outputs.go_version }}


### PR DESCRIPTION
The suffix and branch changes help us avoid duplicate PRs (hopefully) and the
commit message and pr body changes are just nice for clarity.